### PR TITLE
数据表对应的 Schema 文件生成工具

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ pom.xml.next
 release.properties
 .idea
 *.iml
+dbschema/config/*.properties
 
 #ignore auto generated for test.
 gen/
+dbschema/schemas/

--- a/dbschema/config/config.properties-tmpl
+++ b/dbschema/config/config.properties-tmpl
@@ -1,0 +1,11 @@
+# Generate specific tables, split with comma(,)
+tables=BASE_USER,BASE_ROLE,BASE_USER_ROLE,BASE_AUTHORITY,BASE_ROLE_AUTH
+
+# If precision is high,floating type is BigDecimal, and else is Double
+precision=
+
+# if set the value, the prefix of table will be removed when generate code
+tablePrefix=
+
+# generate specific layers(selectable value: dbschema), split with comma(,).
+layers=dbschema

--- a/dbschema/config/jdbc.properties-tmpl
+++ b/dbschema/config/jdbc.properties-tmpl
@@ -1,0 +1,16 @@
+jdbc.driverClassName=com.mysql.jdbc.Driver
+jdbc.url=jdbc:mysql://localhost:3306/ethan
+jdbc.username=primecocn
+jdbc.password=primecocn
+
+#oracle jdbc driver information
+#jdbc.driverClassName=oracle.jdbc.driver.OracleDriver
+#jdbc.url=jdbc:oracle:thin:@localhost:1521:ethan
+#jdbc.username=etl
+#jdbc.password=etl
+
+#db2 jdbc driver information
+#jdbc.driverClassName=com.ibm.db2.jcc.DB2Driver
+#jdbc.url=jdbc:db2://localhost:50000/ethan
+#jdbc.username=odsuser
+#jdbc.password=odsuser

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,25 @@
             <version>1.0.1.Final</version>
         </dependency>
 
+        <!-- Mysql -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.31</version>
+        </dependency>
+        <!-- oracle driver -->
+        <!--<dependency>
+            <groupId>com.oracle</groupId>
+            <artifactId>ojdbc14</artifactId>
+            <version>10.2.0.4.0</version>
+        </dependency>-->
+        <!-- db2 driver -->
+        <!--<dependency>
+            <groupId>db2jcc</groupId>
+            <artifactId>db2jcc</artifactId>
+            <version>9.7</version>
+        </dependency>-->
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/codefather/entities/sys/BaseUser.xml
+++ b/src/main/codefather/entities/sys/BaseUser.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entity  java-controller="1" table="BaseUser">
+    <key name="base_user_id" type="integer" generated="false" />
+
+    <property name="login_id" type="varchar" />
+    <property name="password" type="varchar" />
+    <property name="username" type="varchar" />
+    <property name="status_cd" type="varchar" />
+    <property name="record_flag" type="char" />
+    <property name="created_by" type="integer" />
+    <property name="created_at" type="timestamp" />
+    <property name="updated_by" type="integer" />
+    <property name="updated_at" type="timestamp" />
+</entity>

--- a/src/main/java/com/github/SimonXianyu/codefather/BaseCodeFatherMojo.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/BaseCodeFatherMojo.java
@@ -19,12 +19,12 @@ import java.io.IOException;
 public abstract class BaseCodeFatherMojo extends AbstractMojo {
     /**
      * Field of maven project information
-     * @parameter expression="${project}"
+     * @parameter property="project"
      */
     protected MavenProject project;
     /**
      * codefather path, relative to project path
-     * @parameter expression="${codeFatherPath}", default-value="src/main/codefather"
+     * @parameter property="codeFatherPath", default-value="src/main/codefather"
      */
     protected String codeFatherPath = "src/main/codefather";
     // ================ internal properties from here ======================

--- a/src/main/java/com/github/SimonXianyu/codefather/ConfigConstants.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/ConfigConstants.java
@@ -1,0 +1,11 @@
+package com.github.SimonXianyu.codefather;
+
+/**
+ * Created by Ethan on 4/2.
+ */
+public class ConfigConstants {
+    public static String CONFIG = "./dbschema/config/config.properties";
+    public static String JDBC = "./dbschema/config/jdbc.properties";
+    public static String SCHEMA_PATH = "./dbschema/schemas/";
+    public static String TEMPLATE_PATH = "./dbschema/template";
+}

--- a/src/main/java/com/github/SimonXianyu/codefather/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/generator/SchemaGenerator.java
@@ -1,0 +1,119 @@
+package com.github.SimonXianyu.codefather.generator;
+
+import com.github.SimonXianyu.codefather.ConfigConstants;
+import com.github.SimonXianyu.codefather.util.DBUtils;
+import com.github.SimonXianyu.codefather.util.FileUtils;
+import com.github.SimonXianyu.codefather.util.PropertiesUtils;
+import com.github.SimonXianyu.codefather.util.StringUtils;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+
+public class SchemaGenerator {
+    private List<String> tableList;
+
+    /**
+     * Generate the schema files by given tables' name from the config file
+     * Created on 8/18
+     */
+    public void generatorSchemas() {
+        FileUtils.createSchemaDirectory();
+
+        this.setTableList();
+
+        // generate the schema file of every table
+        Map<String, String> pkMap = null;
+        for (String tableName : this.tableList) {
+            try {
+                pkMap = DBUtils.getPrimaryKeys(tableName);
+            } catch (Exception e) {
+                System.err.println(tableName
+                        + " doesn't exist or connection exception, please check it.");
+                return;
+            }
+
+            if (!pkMap.isEmpty()) {
+                String layers = PropertiesUtils.getLayers();
+                if (layers.contains("dbschema")) {
+                    this.generateSchema(tableName, pkMap);
+                }
+                System.out.println(tableName + " has been generated.");
+            } else {
+                System.err.println(tableName + " has no pk, ignored.");
+            }
+        }
+
+        System.out.println("All finished.");
+    }
+
+    /**
+     * Generate the schema file by table name and the primary key map.
+     * @param tableName
+     * @param pkMap
+     */
+    private void generateSchema(String tableName, Map<String, String> pkMap) {
+        DatabaseMetaData meta = DBUtils.getDatabaseMetaData();
+        String schemaName = StringUtils.firstUpperAndNoPrefix(tableName);
+
+        try {
+            StringBuilder schemaSb = new StringBuilder();
+            schemaSb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+            schemaSb.append("<entity "
+                    + " java-controller=\"1\""
+                    + " table=\"" + schemaName + "\""
+                    + ">\n");
+
+            StringBuilder sbKeys = new StringBuilder();
+            StringBuilder sbColumns = new StringBuilder();
+
+            ResultSet columns = meta.getColumns(null, "%", tableName, "%");
+            if (pkMap.size() > 1) {
+                // 目前设计的数据库没有复合主键
+            } else {
+                while (columns.next()) {
+                    String columnName = columns.getString("COLUMN_NAME"); // 列名
+                    // java.sql.Types 类型名称
+                    String dataTypeName = columns.getString("TYPE_NAME");
+                    int columnSize = columns.getInt("COLUMN_SIZE");
+                    if (pkMap.containsKey(columnName.toLowerCase())) {
+                        sbKeys.append("    <key name=\"" + columnName.toLowerCase() + "\" type=\""
+                                + dataTypeName.toLowerCase() + "\" generated=\"false\" />\n");
+                    } else {
+                        sbColumns.append("    <property name=\"" + columnName.toLowerCase() + "\" type=\""
+                                + dataTypeName.toLowerCase() + "\" />\n");
+                    }
+                }
+            } // else end
+
+            schemaSb.append(sbKeys);
+            schemaSb.append("\n");
+            schemaSb.append(sbColumns);
+            schemaSb.append("</entity>\n");
+
+            String dbSchemaDir = ConfigConstants.SCHEMA_PATH;
+            FileUtils.write(schemaSb.toString(), dbSchemaDir + StringUtils.firstUpperAndNoPrefix(tableName) + ".xml");
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Get the list of table's name from the config file
+     * Created on 8/18.
+     */
+    private void setTableList() {
+        try {
+            this.tableList = PropertiesUtils.getTableList();
+            if (this.tableList.size() == 0) {
+                this.tableList = DBUtils.getAllTables();
+            }
+        } catch (Exception e) {
+            System.err.println("connection exception, please check it.");
+            return;
+        }
+    }
+
+}

--- a/src/main/java/com/github/SimonXianyu/codefather/util/DBUtils.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/util/DBUtils.java
@@ -1,0 +1,274 @@
+package com.github.SimonXianyu.codefather.util;
+
+import com.github.SimonXianyu.codefather.ConfigConstants;
+
+import java.io.FileInputStream;
+import java.sql.*;
+import java.util.*;
+
+public class DBUtils {
+    /**
+     * @return
+     * @date 2015年3月12日 下午8:35:27
+     * @Descriptoin Get nameList of all tables
+     */
+    public static List<String> getAllTables() {
+        List<String> tableList = new ArrayList<String>();
+        try {
+            DatabaseMetaData meta = getDatabaseMetaData();
+            ResultSet rs = null;
+            if ("mysql".equals(getDatabaseType())) {
+                rs = meta.getTables(null, "%", "%", new String[]{"TABLE"});
+            } else if ("oracle".equals(getDatabaseType())) {
+                rs = meta.getTables(null, getUsername(), "%", new String[]{"TABLE"});
+            } else if ("db2".equals(getDatabaseType())) {
+                rs = meta.getTables(null, "odsuser", "%", new String[]{"TABLE"});
+            }
+            while (rs.next()) {
+                tableList.add(rs.getString("TABLE_NAME"));
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return tableList;
+    }
+
+    /**
+     * @return
+     * @date 2015年3月12日 下午8:36:14
+     * @Descriptoin Get the Database MetaData
+     */
+    public static DatabaseMetaData getDatabaseMetaData() {
+        Connection connection = getConnection();
+        DatabaseMetaData meta = null;
+        try {
+            meta = connection.getMetaData();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return meta;
+    }
+
+    /**
+     * @return
+     * @date 2015年3月12日 下午8:36:26
+     * @Descriptoin Get the Database connection
+     */
+    public static Connection getConnection() {
+        Properties prop = new Properties();
+        Connection connection = null;
+        try {
+            prop.load(new FileInputStream(ConfigConstants.JDBC));
+            String driverClassName = prop.getProperty("jdbc.driverClassName");
+            String url = prop.getProperty("jdbc.url");
+            String userName = prop.getProperty("jdbc.username");
+            String password = prop.getProperty("jdbc.password");
+            Class.forName(driverClassName);
+            connection = DriverManager.getConnection(url, userName, password);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return connection;
+    }
+
+    /**
+     * @return
+     * @date 2015年3月12日 下午8:41:53
+     * @Descriptoin Get the Database type
+     */
+    public static String getDatabaseType() {
+        Properties prop = new Properties();
+        try {
+            prop.load(new FileInputStream(ConfigConstants.JDBC));
+            String driverClassName = prop.getProperty("jdbc.driverClassName");
+            if (driverClassName.contains("mysql")) {
+                return "mysql";
+            } else if (driverClassName.contains("oracle")) {
+                return "oracle";
+            } else if (driverClassName.contains("db2")) {
+                return "db2";
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * @return
+     * @date 2015年3月12日 下午8:41:20
+     * @Descriptoin Get the username of Oracle
+     */
+    public static String getUsername() {
+        String dbType = getDatabaseType();
+        String instance = null;
+        if ("oracle".equals(dbType)) {
+            try {
+                Properties prop = new Properties();
+                prop.load(new FileInputStream(ConfigConstants.JDBC));
+                String username = prop.getProperty("jdbc.username");
+                if (username != null) {
+                    instance = username.toUpperCase();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * @param tableName
+     * @return primary key if table contains one
+     * 2015年3月12日 下午8:52:46
+     */
+    public static Map<String, String> getPrimaryKeys(String tableName) {
+        Map<String, String> map = new HashMap();
+        try {
+            ResultSet pkRSet = getDatabaseMetaData().getPrimaryKeys(null, null, tableName);
+            while (pkRSet.next()) {
+                String primaryKey = pkRSet.getString("COLUMN_NAME");
+                String primaryKeyType = getColumnNameTypeMap(pkRSet.getString("TABLE_NAME")).get(
+                        primaryKey);
+                map.put(primaryKey.toLowerCase(), primaryKeyType);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return map;
+    }
+
+    /**
+     * @param tableName
+     * @return
+     * @date 2015年3月12日 下午8:58:43
+     * @Descriptoin Get the map of cloumnName and columnType by tableName
+     */
+    public static Map<String, String> getColumnNameTypeMap(String tableName) {
+        Map<String, String> colMap = new LinkedHashMap<String, String>();
+        DatabaseMetaData meta = getDatabaseMetaData();
+        try {
+            ResultSet colRet = meta.getColumns(null, "%", tableName, "%");
+            while (colRet.next()) {
+                String columnName = colRet.getString("COLUMN_NAME");
+                int digits = colRet.getInt("DECIMAL_DIGITS");
+                int dataType = colRet.getInt("DATA_TYPE");
+                String columnType = null;
+                String typeName = colRet.getString("TYPE_NAME");
+                int columnSize = colRet.getInt("COLUMN_SIZE");
+                if ("mysql".equals(getDatabaseType())) {
+                    columnType = getDataType(dataType, digits);
+                } else if ("oracle".equals(getDatabaseType())) {
+                    columnType = getDataTypeForOracle(typeName, columnSize, digits);
+                } else if ("db2".equals(getDatabaseType())) {
+                    columnType = getDataType(dataType, digits);
+                }
+                colMap.put(columnName, columnType);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return colMap;
+    }
+
+    /**
+     * @param type
+     * @param digits
+     * @return
+     * @date 2015年3月12日 下午9:01:53
+     * @Descriptoin Translate database type into java type
+     */
+    private static String getDataType(int type, int digits) {
+        String dataType = "";
+        switch (type) {
+            case Types.VARCHAR: // 12
+                dataType = "String";
+                break;
+            case Types.INTEGER: // 4
+                dataType = "Integer";
+                break;
+            case Types.BIT: // -7
+                dataType = "Integer";
+                break;
+            case Types.LONGVARCHAR: // -1
+                dataType = "Long";
+                break;
+            case Types.BIGINT: // -5
+                dataType = "Long";
+                break;
+            case Types.DOUBLE: // 8
+                dataType = getPrecisionType();
+                break;
+            case Types.REAL: // 7
+                dataType = getPrecisionType();
+                break;
+            case Types.FLOAT: // 6
+                dataType = getPrecisionType();
+                break;
+            case Types.DECIMAL: // 3
+                dataType = "BigDecimal";
+                break;
+            case Types.NUMERIC: // 2
+                switch (digits) {
+                    case 0:
+                        dataType = "Integer";
+                        break;
+                    default:
+                        dataType = getPrecisionType();
+                }
+                break;
+            case Types.DATE: // 91
+                dataType = "Date";
+                break;
+            case Types.TIMESTAMP: // 93
+                dataType = "Date";
+                break;
+            default:
+                dataType = "String";
+        }
+        return dataType;
+    }
+
+    /**
+     * @param typeName
+     * @param columnSize
+     * @param digits
+     * @return
+     * @date 2015年3月12日 下午9:03:01
+     * @Descriptoin Get data type for Oracle
+     */
+    private static String getDataTypeForOracle(String typeName, int columnSize, int digits) {
+        String dataType = "";
+        if ("VARCHAR2".equals(typeName)) {
+            dataType = "String";
+        } else if ("DATE".equals(typeName)) {
+            dataType = "Date";
+        } else if (typeName.contains("TIMESTAMP")) {
+            dataType = "Timestamp";
+        } else if ("NUMBER".equals(typeName) && digits > 0) {
+            dataType = getPrecisionType();
+        } else if ("NUMBER".equals(typeName) && digits == 0 && columnSize <= 10) {
+            dataType = "Integer";
+        } else if ("NUMBER".equals(typeName) && digits == 0 && columnSize > 10) {
+            dataType = "Long";
+        } else {
+            dataType = "String";
+        }
+        return dataType;
+    }
+
+    /**
+     * @return
+     * @date 2015年3月12日 下午9:03:48
+     * @Descriptoin Get precision from config.properties
+     */
+    private static String getPrecisionType() {
+        String dataType;
+        if ("high".equals(PropertiesUtils.getPrecision())) {
+            dataType = "BigDecimal";
+        } else {
+            dataType = "Double";
+        }
+        return dataType;
+    }
+}

--- a/src/main/java/com/github/SimonXianyu/codefather/util/FileUtils.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/util/FileUtils.java
@@ -1,0 +1,91 @@
+package com.github.SimonXianyu.codefather.util;
+
+import com.github.SimonXianyu.codefather.ConfigConstants;
+
+import java.io.*;
+
+public class FileUtils {
+    /**
+     * 2015年3月12日 下午9:49:21
+     */
+    public static void createSchemaDirectory() {
+        /*String location = PropertiesUtils.getLocation();
+        String project = PropertiesUtils.getProject();
+        if (project != null && !"".equals(project)) {
+            location = location + "/src";
+        }
+        String dbSchemaDir = location + "/dbschema";*/
+
+        String dbSchemaDir = ConfigConstants.SCHEMA_PATH;
+        mkdir(dbSchemaDir);
+    }
+
+    /**
+     * 2015年3月12日 下午9:49:15
+     * @param dir
+     */
+    private static void mkdir(String dir) {
+        File file;
+        file = new File(dir);
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+    }
+
+    /**
+     * 2015年3月12日 下午9:49:25
+     * @param template
+     * @return
+     * Get the template file
+     */
+    public static String getTemplate(String template) {
+        String path = ConfigConstants.TEMPLATE_PATH + "/single";
+        File file = new File(path + template);
+        return read(file);
+    }
+
+    /**
+     * 2015年3月12日 下午9:49:30
+     * @param file
+     * @return
+     */
+    public static String read(File file) {
+        StringBuilder res = new StringBuilder();
+        String line;
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            int i = 0;
+            while ((line = reader.readLine()) != null) {
+                if (i != 0) {
+                    res.append('\n');
+                }
+                res.append(line);
+                i++;
+            }
+            reader.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return res.toString();
+    }
+
+    /**
+     * 2015年3月13日 上午1:04:52
+     * @param content
+     * @param path
+     * @return
+     */
+    public static boolean write(String content, String path) {
+        try {
+            File file = new File(path);
+            BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+            writer.write(content);
+            writer.flush();
+            writer.close();
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/github/SimonXianyu/codefather/util/PropertiesUtils.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/util/PropertiesUtils.java
@@ -1,0 +1,123 @@
+package com.github.SimonXianyu.codefather.util;
+
+import com.github.SimonXianyu.codefather.ConfigConstants;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class PropertiesUtils {
+    private static Properties prop;
+
+    static {
+        prop = new Properties();
+        try {
+            prop.load(new FileInputStream(new File(ConfigConstants.CONFIG)));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 2015年3月12日 下午8:29:40
+     * @return
+     * Get table names from config.properties
+     */
+    public static List<String> getTableList() {
+        List<String> list = new ArrayList<String>();
+        try {
+            String tables = prop.getProperty("tables");
+            String[] tableArr = tables.split(",");
+            for (String str : tableArr) {
+                str = str.trim();
+                if (!"".equals(str)) {
+                    list.add(str);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    /**
+     * 2015年3月12日 下午8:55:48
+     * @return
+     * If precision is high,floating type is BigDecimal, and else
+     *              is Double
+     */
+    public static String getPrecision() {
+        String precision = prop.getProperty("precision");
+        if (precision == null) {
+            precision = "";
+        }
+        return precision.toLowerCase().trim();
+    }
+
+    /**
+     * 2015年3月12日 下午9:22:29
+     * @return
+     */
+    public static String getLocation() {
+        String location = prop.getProperty("location");
+        if (location != null) {
+            location = location.trim();
+        }
+        String project = getProject();
+        if (project != null && !"".equals(project)) {
+            location = location + "/" + project;
+        }
+        return location;
+    }
+
+    /**
+     * 2015年3月12日 下午9:23:00
+     * @return
+     */
+    public static String getProject() {
+        String project = prop.getProperty("project");
+        if (project != null) {
+            project = project.trim();
+        }
+        return project;
+    }
+
+    /**
+     * 2015年3月12日 下午9:27:17
+     * @return
+     */
+    public static String getPackage() {
+        String cgpackage = prop.getProperty("package");
+        if (cgpackage != null) {
+            cgpackage = cgpackage.trim();
+        }
+        return cgpackage;
+    }
+
+    /**
+     * 2015年3月12日 下午9:47:10
+     * @return
+     */
+    public static String getLayers() {
+        String layers = prop.getProperty("layers");
+        if (layers == null || "".equals(layers)) {
+            layers = "dbschema,dao,mapper,service,controller,model,jsp,test";
+        }
+        return layers.toLowerCase().trim();
+    }
+
+    /**
+     * 2015年3月12日 下午9:47:14
+     * @return
+     */
+    public static String getTablePrefix() {
+        String tablePrefix = prop.getProperty("tablePrefix");
+        if (tablePrefix == null) {
+            tablePrefix = "";
+        }
+        return tablePrefix.toLowerCase().trim();
+    }
+
+}

--- a/src/main/java/com/github/SimonXianyu/codefather/util/StringUtils.java
+++ b/src/main/java/com/github/SimonXianyu/codefather/util/StringUtils.java
@@ -1,0 +1,78 @@
+package com.github.SimonXianyu.codefather.util;
+
+public class StringUtils {
+    public static void main(String[] args) {
+        System.out.println(formatAndNoPrefix("KB_CARD"));
+    }
+
+    /**
+     * @date 2015年3月12日 下午9:46:17
+     * @param string
+     * @return
+     * @Descriptoin Format database type into java type, eg format "card_type"  into "cardType"
+     */
+    public static String format(String string) {
+        StringBuilder sb = new StringBuilder();
+        char[] cArr = string.trim().toLowerCase().toCharArray();
+        for (int i = 0; i < cArr.length; i++) {
+            char c = cArr[i];
+            if (c == '_') {
+                i++;
+                sb.append(Character.toUpperCase(cArr[i]));
+            } else {
+                sb.append(c);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * @date 2015年3月12日 下午9:51:51
+     * @param tableName
+     * @return
+     * @Descriptoin
+     */
+    public static String formatAndNoPrefix(String tableName) {
+        String noPrefixTableName = tableName.toLowerCase().replaceFirst(
+                PropertiesUtils.getTablePrefix(), "");
+        noPrefixTableName = format(noPrefixTableName);
+        return noPrefixTableName;
+    }
+
+    /**
+     * @date 2015年3月12日 下午9:51:54
+     * @param string
+     * @return
+     * @Descriptoin
+     */
+    public static String firstUpper(String string) {
+        String str = format(string);
+        str = str.substring(0, 1).toUpperCase() + str.substring(1);
+        return str;
+    }
+
+    /**
+     * @date 2015年3月12日 下午9:51:57
+     * @param tableName
+     * @return
+     * @Descriptoin
+     */
+    public static String firstUpperAndNoPrefix(String tableName) {
+        String noPrefixTableName = tableName.toLowerCase().replaceFirst(
+                PropertiesUtils.getTablePrefix(), "");
+        noPrefixTableName = firstUpper(noPrefixTableName);
+        return noPrefixTableName;
+    }
+
+    /**
+     * @date 2015年3月12日 下午9:52:01
+     * @param string
+     * @return
+     * @Descriptoin
+     */
+    public static String firstUpperNoFormat(String string) {
+        String str = string.substring(0, 1).toUpperCase() + string.substring(1);
+        return str;
+    }
+}

--- a/src/test/java/com/github/SimonXianyu/codefather/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/SimonXianyu/codefather/generator/SchemaGeneratorTest.java
@@ -1,0 +1,77 @@
+package com.github.SimonXianyu.codefather.generator;
+
+import org.junit.Test; 
+import org.junit.Before; 
+import org.junit.After; 
+
+/** 
+* SchemaGenerator Tester. 
+* 
+* @author <Authors name> 
+* @since <pre>8/19, 2015</pre>
+* @version 1.0 
+*/ 
+public class SchemaGeneratorTest {
+    private SchemaGenerator generator;
+
+    @Before
+    public void before() throws Exception {
+        generator = new SchemaGenerator();
+    } 
+
+    @After
+    public void after() throws Exception { 
+    } 
+
+    /** 
+     * 
+     * Method: generatorSchemas() 
+     * 
+     */ 
+    @Test
+    public void testGeneratorSchemas() throws Exception {
+        generator.generatorSchemas();
+    } 
+
+
+    /** 
+     * 
+     * Method: generateSchema(String tableName, Map<String, String> pkMap) 
+     * 
+     */ 
+    @Test
+    public void testGenerateSchema() throws Exception { 
+        //TODO: Test goes here... 
+    /* 
+    try { 
+       Method method = SchemaGenerator.getClass().getMethod("generateSchema", String.class, Map<String,.class); 
+       method.setAccessible(true); 
+       method.invoke(<Object>, <Parameters>); 
+    } catch(NoSuchMethodException e) { 
+    } catch(IllegalAccessException e) { 
+    } catch(InvocationTargetException e) { 
+    } 
+    */ 
+    } 
+
+    /** 
+     * 
+     * Method: setTableList() 
+     * 
+     */ 
+    @Test
+    public void testSetTableList() throws Exception { 
+        //TODO: Test goes here... 
+    /* 
+    try { 
+       Method method = SchemaGenerator.getClass().getMethod("setTableList"); 
+       method.setAccessible(true); 
+       method.invoke(<Object>, <Parameters>); 
+    } catch(NoSuchMethodException e) { 
+    } catch(IllegalAccessException e) { 
+    } catch(InvocationTargetException e) { 
+    } 
+    */ 
+    } 
+
+} 


### PR DESCRIPTION
【新增功能】
手动创建数据表对应的 Schema 文件很费事，所以写了一个工具，配置好 JDBC 后，可以生成 config 中指定的表的 schema 文件。年初写了一个是针对 MySql 数据库（在codemother中使用）的，现在因为使用的 DB2 数据库，所以补充了针对 DB2 的代码。
【说明】
大体功能是基于最初的 codemother 中的功能，代码风格基本一致，但是关于注释的风格不太一致。
现在生成的 Schema 文件结构很简单，主要原因是对 codefather 还不熟悉，之前使用的一直是 codemother. 
在项目根目录创建 dbschema 文件的目的是希望可以把公共的配置抽出来，在项目中可以被不同模块共用。
